### PR TITLE
Fix typos

### DIFF
--- a/docs/guides/usage/tables.livemd
+++ b/docs/guides/usage/tables.livemd
@@ -1798,7 +1798,7 @@ The `:ets.lookup/1` function lets us get our objects by their key — the first 
 "Emboar"
 ```
 
-The 500th Pokémon appears to be some creature called Emboar. This scares and confuses me, as I am an elder millenial who never moved on from the 1st generation of 151 Pokémon, and refuse to believe anything has changed from my childhood.
+The 500th Pokémon appears to be some creature called Emboar. This scares and confuses me, as I am an elder millennial who never moved on from the 1st generation of 151 Pokémon, and refuse to believe anything has changed from my childhood.
 
 <!-- livebook:{"break_markdown":true} -->
 
@@ -2746,12 +2746,12 @@ This is what the "mapping" aspect of match specs refers to: that we can not only
 
 <!-- livebook:{"break_markdown":true} -->
 
-Just as data in a list in Elixir need not be homogenous, but can contain any term; objects in the same `:ets` table can be any term — just so long as they are all tuples, and all have a key entry at the same position in the tuples:
+Just as data in a list in Elixir need not be homogeneous, but can contain any term; objects in the same `:ets` table can be any term — just so long as they are all tuples, and all have a key entry at the same position in the tuples:
 
 ```elixir
-hetrogenous_table = :ets.new(HetrogenousTable, [:set])
+heterogenous_table = :ets.new(HeterogenousTable, [:set])
 
-:ets.insert(hetrogenous_table, [
+:ets.insert(Heterogenous_table, [
   {3, "three", "tuple"},
   {4, "four", "tuple", "object"}
 ])
@@ -2769,7 +2769,7 @@ Our match specs can use multiple clauses to match on these different object shap
 alias Matcha.Table.ETS
 require ETS
 
-ETS.select hetrogenous_table do
+ETS.select heterogenous_table do
   {_key, length, _} -> length
   {_key, length, _, _} -> length
 end
@@ -2781,13 +2781,13 @@ end
 ["four", "three"]
 ```
 
-We can also return hetrogenous shapes from `:ets`, our mapping operation need not always shape query results the same:
+We can also return heterogeneous shapes from `:ets`, our mapping operation need not always shape query results the same:
 
 ```elixir
 alias Matcha.Table.ETS
 require ETS
 
-ETS.select hetrogenous_table do
+ETS.select heterogenous_table do
   {_key, _, _} -> [{:three, :object, :shape}]
   {_key, _, _, _} -> [{:four, :object, :shape, :tuple}]
 end

--- a/docs/guides/usage/tracing.livemd
+++ b/docs/guides/usage/tracing.livemd
@@ -216,7 +216,7 @@ But, what if we want to be even more specific about what `base` we are intereste
 
 ## Tracing Specific Arguments
 
-Elixir also supports [**_function overloading_**](https://en.wikipedia.org/wiki/Function_overloading), providing different implementations for a function depending on the _specific kinds_ of arguments it is invoked with. In many languages, this is acheived base on a type system; in Elixir, we use pattern matching in the function head and guards to steer our function calls to a specific implementation.
+Elixir also supports [**_function overloading_**](https://en.wikipedia.org/wiki/Function_overloading), providing different implementations for a function depending on the _specific kinds_ of arguments it is invoked with. In many languages, this is achieved base on a type system; in Elixir, we use pattern matching in the function head and guards to steer our function calls to a specific implementation.
 
 <!-- livebook:{"break_markdown":true} -->
 
@@ -224,7 +224,7 @@ We can use match specifications to complement this feature, and describe exactly
 
 <!-- livebook:{"break_markdown":true} -->
 
-For example, imagine that we are only trying to understand how often we parse a string into a _binary_ number—even though a bizzare part of our codebase is also parsing things into _trinary_ numbers as well.
+For example, imagine that we are only trying to understand how often we parse a string into a _binary_ number—even though a bizarre part of our codebase is also parsing things into _trinary_ numbers as well.
 
 If we provide the tracing engine with a match specification using the `Matcha.spec/2` macro, we can pattern match on precisely the arguments we want to be notified about:
 
@@ -337,7 +337,7 @@ For more details on these special tracing-only functions, consult the `Matcha.Co
 
 <!-- livebook:{"break_markdown":true} -->
 
-As a somewhat contrived example: let's say that even when we have a large `:limit`, we want to supress tracing messages after a function call with specific arguments is traced:
+As a somewhat contrived example: let's say that even when we have a large `:limit`, we want to suppress tracing messages after a function call with specific arguments is traced:
 
 ```elixir
 require Matcha
@@ -376,7 +376,7 @@ Matcha.Trace: `Elixir.Integer.parse("123", 3)` called on #PID<0.142.0>: integer 
 Matcha.Trace: `Elixir.Integer.parse("123", 3)` called on #PID<0.142.0>: integer parsed into trinary
 ```
 
-Setting aside the structure of our function calls, there are other ways to filter what trace messages we recieve.
+Setting aside the structure of our function calls, there are other ways to filter what trace messages we receive.
 
 ## Tracing Specific Processes
 

--- a/lib/matcha/context.ex
+++ b/lib/matcha/context.ex
@@ -92,7 +92,7 @@ defmodule Matcha.Context do
 
   This function is used to provide `Matcha.Source.test/3` with a target value to test against,
   in situations where it is being used to simply validate the match spec itself,
-  but we do not acutally care if the input matches the spec.
+  but we do not actually care if the input matches the spec.
 
   This value, when passed to this context's `c:Matcha.Context.__valid_match_target__/1` callback,
   must produce a `true` value.

--- a/lib/matcha/context/trace.ex
+++ b/lib/matcha/context/trace.ex
@@ -257,7 +257,7 @@ defmodule Matcha.Context.Trace do
   @doc """
   Changes the verbosity of the current process's messaging `mode`.
 
-  - If `mode` is `true`, supresses all trace messages.
+  - If `mode` is `true`, suppresses all trace messages.
   - If `mode` is `false`, re-enables trace messages in future calls.
   - If `mode` is anything else, the current mode remains active.
   """
@@ -482,7 +482,7 @@ defmodule Matcha.Context.Trace do
   @compile {:inline, get_seq_token: 0}
   @spec get_seq_token() :: seq_token | []
   @doc """
-  Retreives the (opaque) value of the trace token for the current process.
+  Retrieves the (opaque) value of the trace token for the current process.
 
   If the current process is not being traced, returns `[]`.
 


### PR DESCRIPTION
Found via `codespell -S deps` and `typos --format brief`.